### PR TITLE
Update Config.json Samples for cmd4 v3.0.15

### DIFF
--- a/HisenseSwitch.sh
+++ b/HisenseSwitch.sh
@@ -14,7 +14,7 @@ if [ "$1" = "Get" ]; then
 
     On )
       # Polls the TV over your network to see if it is still active.
-      if [ $(timeout 2 /bin/bash -c "(echo > /dev/tcp/"$ip"/36669) > /dev/null 2>&1 && echo 1 || echo 0")  = '1' ]; then
+      if [ $(timeout 2 /bin/bash -c "(echo > /dev/tcp/"$ip"/36669) > /dev/null 2>&1 && echo 1 || echo 0)"  = '1' ]; then
         echo 1
       else
         echo 0
@@ -28,7 +28,7 @@ if [ "$1" = "Set" ]; then
   case "$3" in
 
     On )
-      if [ "$4" = "true" ]; then
+      if [ "$4" = "1" ]; then
         # TV can only be turned back on by WOL using your TV MAC ADDRESS.
         wakeonlan "$tvMAC"
       else

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ qmierjfpaoisdjmçfaisldjcçfskdjafcaçskdjcçfmasidcf (etc. etc. etc)
 15. Restart Homebridge and all should be well... Unless you are me and everything I do goes wrong several times before it goes right haha.
 
 ## Known Bug:
-<B>Right now there is a breaking issue in homebridge-cmd4 `v.3.0.x` that causes issues with 'set' commands. Please continue to use homebridge-cmd4 `v2.4.4` until these issues have been sorted out. The jump to `v.3.0.x` also requires breaking changes in your `config.json`, which will be updated here when stable. </B> [Issue here.](https://github.com/ztalbot2000/homebridge-cmd4/issues/76)
+~~<B>Right now there is a breaking issue in homebridge-cmd4 `v.3.0.x` that causes issues with 'set' commands. Please continue to use homebridge-cmd4 `v2.4.4` until these issues have been sorted out. The jump to `v.3.0.x` also requires breaking changes in your `config.json`, which will be updated here when stable. </B> [Issue here.](https://github.com/ztalbot2000/homebridge-cmd4/issues/76)~~
 
 ## Troubleshooting:
 - After `Step 9` and before `Step 10`; you can run the following two commands to see that you have the certs and your MAC Address correct. If the following commands do not work, then you have done something wrong with the certificatess or the MAC Addressfor the paired device and it is the not a problem the shell script or `homebridge-cmd4`. 

--- a/config_sample_switch.json
+++ b/config_sample_switch.json
@@ -1,10 +1,11 @@
 {
             "platform": "Cmd4",
             "name": "Cmd4",
-            "outputConstants": true,
+            "restartRecover": false,
             "accessories": [
                 {
                     "type": "Switch",
+                    "outputConstants": true,
                     "displayName": "My_Switch",
                     "on": "FALSE",
                     "name": "Hisense",

--- a/config_sample_switch.json
+++ b/config_sample_switch.json
@@ -1,11 +1,11 @@
 {
             "platform": "Cmd4",
             "name": "Cmd4",
+            "outputConstants": false,
             "restartRecover": false,
             "accessories": [
                 {
                     "type": "Switch",
-                    "outputConstants": true,
                     "displayName": "My_Switch",
                     "on": "FALSE",
                     "name": "Hisense",


### PR DESCRIPTION
The breaking change with homebridge-cmd4 `v3.0.x` appears to be resolved in `v3.0.15`. This PR contains the changes required in the Homebridge `config.json` file for the new homebridge-cmd4 version to work at its best. I will hold off on the merge until I have the seal of approval from the developer of cmd4.